### PR TITLE
Create new endpoint for delete crm data

### DIFF
--- a/crm_integration_xblock/salesforce_tasks.py
+++ b/crm_integration_xblock/salesforce_tasks.py
@@ -72,11 +72,16 @@ class SalesForce(object):
         else:
             return {"success": True}
 
-    def delete(self):
+    def delete(self, salesforce_object, id_object):
         """
-        TODO
+        Delete objects one by one
         """
-        pass
+        url = "{base}{object}/{id}".format(base=self.base_url,
+                                           object=salesforce_object,
+                                           id=id_object)
+
+        response = requests.request("DELETE", url, headers=self.headers)
+        return response
 
     def bulk(self, salesforce_object, data):
         """

--- a/crm_integration_xblock/varkey_validations.py
+++ b/crm_integration_xblock/varkey_validations.py
@@ -74,6 +74,17 @@ class SalesForceVarkey(SalesForce):
         salesforce_response = json.loads(response.text)
         return {"message": salesforce_response, "status_code": response.status_code}
 
+    def _delete_data(self, data):
+        """
+        Delete records one by one.
+        """
+        salesforce_object = data["initial"]["object_sf"]
+        records_to_delete = data["id"]
+        for record in records_to_delete:
+            self.delete(salesforce_object, record)
+
+        return {"success":True}
+
     def _validate_cue(self, data):
         """
         Method that look for CUE id in Account object.


### PR DESCRIPTION
This PR creates a new endpoint to delete CRM data which call a "private" method directly in Varkey validations receiving a list of ids of SalesForce objects. Which in turn also call the delete method in SalesForce API.


