### PR TITLE
Fixing errors due to the badly initialized callback

### DIFF
--- a/crm_integration_xblock/static/js/src/crm-integration-xblock.js
+++ b/crm_integration_xblock/static/js/src/crm-integration-xblock.js
@@ -15,7 +15,11 @@ function CrmIntegrationLms(runtime, element) {
     $.ajax({
         type: "POST",
         url: handlerUrl,
-        data: JSON.stringify({"hello": "world"}),
+        data: JSON.stringify({
+            "initial": {"object_sf":"custom_query"},
+            "custom_query": "SELECT * FROM Some_table WHERE id='{user_id}':",
+            "no_init": "LMS example",
+        }),
         success: crmIntegration.xhrHandler()
     });
 
@@ -33,7 +37,10 @@ function CrmIntegrationStudio(runtime, element) {
     $.ajax({
         type: "POST",
         url: handlerUrl,
-        data: JSON.stringify({"hello": "world"}),
+        data: JSON.stringify({
+            "initial": {"object_sf":"custom_query"},
+            "custom_query": "SELECT * FROM Some_table WHERE id='{user_id}':",
+            "no_init": "Studio example"}),
         success: crmIntegration.xhrHandler()
     });
 

--- a/crm_integration_xblock/varkey_validations.py
+++ b/crm_integration_xblock/varkey_validations.py
@@ -42,7 +42,10 @@ class SalesForceVarkey(SalesForce):
         Mandatory method. For Varkey case handles the way
         wich method to execute in order to validate the forms.
         """
-        salesforce_object = self.initial["object_sf"]
+        salesforce_object = self.initial.get("object_sf")
+
+        if not salesforce_object:
+            return {"message": "The sent data did not contain a valid 'object_sf'", "status_code": 400}
 
         if salesforce_object == "Historial_escuela__c":
             return self._validate_cue(data)


### PR DESCRIPTION
This PR removes the fake example that used "hello world" as the payload. Instead is uses a custom_query payload containing the `no_init` argument, which makes the server avoid initialization and token generation

