### PR TITLE
Enable load of the XBlock when masquerading as a specific user

### DIFF
--- a/crm_integration_xblock/crm_integration_xblock.py
+++ b/crm_integration_xblock/crm_integration_xblock.py
@@ -34,6 +34,9 @@ class CrmIntegration(StudioEditableXBlockMixin, XBlock):
     and holding the private data we don't want to send to the browsers.
     """
 
+    # Show the XBlock when masquerading as a specific user.
+    show_in_read_only_mode = True
+
     display_name = String(
         display_name="Display Name",
         scope=Scope.settings,


### PR DESCRIPTION
###  XBlock load in masquerade mode

### **Description**

XBlocks are not loaded when masquerading as a specific user to prevent any modification to user data by interaction with the XBlock, as defined in [masquerade](https://github.com/edx/edx-platform/blob/972ad9cb1f0810b47050518d64a0ab4adaa3a8e3/lms/djangoapps/courseware/masquerade.py#L278).

### **Reviewers**

- [x] @felipemontoya 

- [ ] @morenol 